### PR TITLE
Create jira_move_tasks.yml

### DIFF
--- a/.github/workflows/jira_move_tasks.yml
+++ b/.github/workflows/jira_move_tasks.yml
@@ -1,0 +1,36 @@
+on:
+  push:
+    branches:
+    - '*'
+    - '!main'
+
+name: Transition Issue for progress
+
+jobs:
+  test-transition-issue:
+    name: Transition Issue
+    runs-on: ubuntu-latest
+    steps:
+    - name: Login
+      uses: atlassian/gajira-login@master
+      env:
+        JIRA_BASE_URL: ${{ secrets.https://three-ppp.atlassian.net }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+    # プッシュされたコミットに記載された課題キーを抽出する
+    - name: Find in commit messages
+      id: find
+      uses: atlassian/gajira-find-issue-key@master
+      with:
+        string: ${{ github.event.ref }}
+
+    # 課題キーが特定できればJiraに対してトランジションを発行　
+    - name: Transition issue
+      uses: atlassian/gajira-transition@master
+      # 課題キーが含まれていなければスルー
+      if: ${{ steps.find.outputs.issue }}
+      with:
+        # 前のステップのアウトプットを参照
+        issue: ${{ steps.find.outputs.issue }}
+        transition: "進行中"


### PR DESCRIPTION
jira のタスクを移動するアクションです　※　mainブランチ以外にプッシュ時

実際にブランチにpushしたときに自動的にタスクの進行度が変わるgithub actionsを実装します。